### PR TITLE
Save a list of search names in City

### DIFF
--- a/cities_light/admin.py
+++ b/cities_light/admin.py
@@ -30,7 +30,7 @@ class CityAdmin(admin.ModelAdmin):
     )
     search_fields = (
         'name',
-        'name_ascii',
+        'search_names',
     )
     list_filter = (
         'country__continent',

--- a/cities_light/autocomplete_light_registry.py
+++ b/cities_light/autocomplete_light_registry.py
@@ -5,6 +5,8 @@ from models import *
 autocomplete_light.register(Country)
 
 class CityChannel(autocomplete_light.ChannelBase):
+    search_field = 'search_names'
+
     def query_filter(self, results):
         results = super(CityChannel, self).query_filter(results)
 

--- a/cities_light/forms.py
+++ b/cities_light/forms.py
@@ -10,4 +10,4 @@ class CountryForm(forms.ModelForm):
 class CityForm(forms.ModelForm):
     class Meta:
         model = City
-        exclude = ('name_ascii', 'slug')
+        exclude = ('name_ascii', 'search_names', 'slug')

--- a/cities_light/lookups.py
+++ b/cities_light/lookups.py
@@ -28,7 +28,7 @@ class CityLookup(StandardLookupChannel):
     def get_query(self, q, request):
         return City.objects.filter(
             Q(name__icontains=q) |
-            Q(ascii_name__icontains=q)
+            Q(search_names__icontains=q)
         ).select_related('country').distinct()
     
     def get_result(self, obj):

--- a/cities_light/migrations/0003_auto__add_field_city_search_names.py
+++ b/cities_light/migrations/0003_auto__add_field_city_search_names.py
@@ -1,0 +1,48 @@
+# encoding: utf-8
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        
+        # Adding field 'City.search_names'
+        db.add_column('cities_light_city', 'search_names', self.gf('django.db.models.fields.TextField')(default='', db_index=True), keep_default=False)
+
+
+    def backwards(self, orm):
+        
+        # Deleting field 'City.search_names'
+        db.delete_column('cities_light_city', 'search_names')
+
+
+    models = {
+        'cities_light.city': {
+            'Meta': {'ordering': "['name']", 'unique_together': "(('country', 'name'),)", 'object_name': 'City'},
+            'country': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cities_light.Country']"}),
+            'geoname_id': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'latitude': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '8', 'decimal_places': '5', 'blank': 'True'}),
+            'longitude': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '8', 'decimal_places': '5', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200', 'db_index': 'True'}),
+            'name_ascii': ('django.db.models.fields.CharField', [], {'max_length': '200', 'db_index': 'True'}),
+            'search_names': ('django.db.models.fields.TextField', [], {'default': "''", 'db_index': 'True'}),
+            'slug': ('autoslug.fields.AutoSlugField', [], {'unique_with': '()', 'max_length': '50', 'populate_from': 'None', 'db_index': 'True'})
+        },
+        'cities_light.country': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Country'},
+            'code2': ('django.db.models.fields.CharField', [], {'max_length': '2', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'code3': ('django.db.models.fields.CharField', [], {'max_length': '3', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'continent': ('django.db.models.fields.CharField', [], {'max_length': '2', 'db_index': 'True'}),
+            'geoname_id': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '200'}),
+            'name_ascii': ('django.db.models.fields.CharField', [], {'max_length': '200', 'db_index': 'True'}),
+            'slug': ('autoslug.fields.AutoSlugField', [], {'unique_with': '()', 'max_length': '50', 'populate_from': 'None', 'db_index': 'True'}),
+            'tld': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '5', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['cities_light']

--- a/cities_light/models.py
+++ b/cities_light/models.py
@@ -50,9 +50,9 @@ signals.pre_save.connect(set_name_ascii, sender=Country)
 
 class City(models.Model):
     name = models.CharField(max_length=200, db_index=True)
-    name_ascii = models.CharField(max_length=200, db_index=True)
     slug = autoslug.AutoSlugField(populate_from='name_ascii', 
         unique_with=('country__name',))
+    search_names = models.TextField(db_index=True, default='')
 
     latitude = models.DecimalField(max_digits=8, decimal_places=5,
         null=True, blank=True)


### PR DESCRIPTION
The geonames data has an handy comma separeted list of alternative
names for the city. Save it in db and hook the autocomplete plugins to
search there too. This let people search people in their native
language instead of in English.

I've kept the name_ascii field because it is used as base for the slug.
