### PR TITLE
Add max_length to City.search_names (#8)

### DIFF
--- a/cities_light/migrations/0003_auto__add_field_city_search_names.py
+++ b/cities_light/migrations/0003_auto__add_field_city_search_names.py
@@ -9,7 +9,7 @@ class Migration(SchemaMigration):
     def forwards(self, orm):
         
         # Adding field 'City.search_names'
-        db.add_column('cities_light_city', 'search_names', self.gf('django.db.models.fields.TextField')(default='', db_index=True), keep_default=False)
+        db.add_column('cities_light_city', 'search_names', self.gf('django.db.models.fields.TextField')(default='', max_length=4000, db_index=True, blank=True), keep_default=False)
 
 
     def backwards(self, orm):
@@ -28,7 +28,7 @@ class Migration(SchemaMigration):
             'longitude': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '8', 'decimal_places': '5', 'blank': 'True'}),
             'name': ('django.db.models.fields.CharField', [], {'max_length': '200', 'db_index': 'True'}),
             'name_ascii': ('django.db.models.fields.CharField', [], {'max_length': '200', 'db_index': 'True'}),
-            'search_names': ('django.db.models.fields.TextField', [], {'default': "''", 'db_index': 'True'}),
+            'search_names': ('django.db.models.fields.TextField', [], {'default': "''", 'max_length': '4000', 'db_index': 'True', 'blank': 'True'}),
             'slug': ('autoslug.fields.AutoSlugField', [], {'unique_with': '()', 'max_length': '50', 'populate_from': 'None', 'db_index': 'True'})
         },
         'cities_light.country': {

--- a/cities_light/models.py
+++ b/cities_light/models.py
@@ -70,7 +70,7 @@ class City(models.Model):
     name_ascii = models.CharField(max_length=200, blank=True, db_index=True)
     slug = autoslug.AutoSlugField(populate_from='name_ascii',
         unique_with=('country__name',))
-    search_names = models.TextField(db_index=True, blank=True, default='')
+    search_names = models.TextField(max_length=4000, db_index=True, blank=True, default='')
 
     latitude = models.DecimalField(max_digits=8, decimal_places=5,
         null=True, blank=True)


### PR DESCRIPTION
Mysql does not like TextField without a length used for indexes:

_mysql_exceptions.OperationalError: (1170, "BLOB/TEXT column 'search_names' used in key specification without a key length")

See https://code.djangoproject.com/ticket/2495

We also change the relevant 0003_auto__add_field_city_search_names.py migration
file to match.
