### PR TITLE
Allow cities_light to run on win32

### DIFF
--- a/cities_light/geonames.py
+++ b/cities_light/geonames.py
@@ -1,4 +1,3 @@
-import resource
 import time
 import urllib
 import os

--- a/cities_light/management/commands/cities_light.py
+++ b/cities_light/management/commands/cities_light.py
@@ -2,7 +2,9 @@ import os
 import os.path
 import logging
 import optparse
-import resource
+import sys
+if sys.platform != 'win32':
+    import resource
 
 try:
     import cPickle as pickle
@@ -23,7 +25,9 @@ from ...geonames import Geonames
 
 class MemoryUsageWidget(progressbar.ProgressBarWidget):
     def update(self, pbar):
-        return '%s kB' % resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        if sys.platform != 'win32':
+            return '%s kB' % resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        return '?? kB'
 
 
 class Command(BaseCommand):


### PR DESCRIPTION
"resource" module is unavailable on win32
