### PR TITLE
use ugettext_lazy instead of ugettext.

### DIFF
--- a/cities_light/models.py
+++ b/cities_light/models.py
@@ -4,7 +4,7 @@ import re
 from django.utils.encoding import force_unicode
 from django.db.models import signals
 from django.db import models
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from south.modelsinspector import add_introspection_rules
 


### PR DESCRIPTION
"This is essential when calls to these functions are located in code paths that are executed at module load time." ugettext_lazy should be used instead. "See https://docs.djangoproject.com/en/dev/topics/i18n/translation/#lazy-translations. This fixes import issue when used with other django apps that have utilities that import installed_apps such as Haystack.
