### PR TITLE
Missing regions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,12 +9,12 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 setup(
-    name='sonic-cities-light',
-    version='1.0.0',
-    description='Sonicbids fork of the simple alternative to django-cities',
+    name='django-cities-light',
+    version='2.0.8',
+    description='Simple alternative to django-cities',
     author='James Pic',
-    author_email='it@sonicbids.com',
-    url='https://github.com/Sonicbids/django-cities-light',
+    author_email='jamespic@gmail.com',
+    url='https://github.com/yourlabs/django-cities-light',
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
I noticed that if a two cities with the same name in a single country exist that only the first one is being imported. This was due to the city import function not checking for region id in addition to the city name and country id when determining if a record was to be edited or created. There are also significant performance improvements: cities1000 now takes 10-15min instead of over two hours.
