### PR TITLE
add population and feature code to improve search results

### DIFF
--- a/cities_light/admin.py
+++ b/cities_light/admin.py
@@ -78,7 +78,7 @@ class CityAdmin(admin.ModelAdmin):
         'country__continent',
         'country',
     )
-    form = CityForm
+    #form = CityForm
 
     def get_changelist(self, request, **kwargs):
         return CityChangeList

--- a/cities_light/management/commands/cities_light.py
+++ b/cities_light/management/commands/cities_light.py
@@ -368,6 +368,14 @@ It is possible to force the import of files which weren't downloaded using the
             city.longitude = items[5]
             save = True
 
+        if not city.population:
+            city.population = items[14]
+            save = True
+
+        if not city.feature_code:
+            city.feature_code = items[7]
+            save = True
+
         if not TRANSLATION_SOURCES and not city.alternate_names:
             city.alternate_names = force_unicode(items[3])
             save = True

--- a/cities_light/migrations/0015_auto__chg_field_country_slug__add_field_city_population__add_field_cit.py
+++ b/cities_light/migrations/0015_auto__chg_field_country_slug__add_field_city_population__add_field_cit.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+
+        # Changing field 'Country.slug'
+        db.alter_column(u'cities_light_country', 'slug', self.gf('autoslug.fields.AutoSlugField')(unique_with=(), max_length=50, populate_from='name_ascii'))
+        # Adding field 'City.population'
+        db.add_column(u'cities_light_city', 'population',
+                      self.gf('django.db.models.fields.BigIntegerField')(db_index=True, null=True, blank=True),
+                      keep_default=False)
+
+        # Adding field 'City.feature_code'
+        db.add_column(u'cities_light_city', 'feature_code',
+                      self.gf('django.db.models.fields.CharField')(db_index=True, max_length=10, null=True, blank=True),
+                      keep_default=False)
+
+
+        # Changing field 'City.slug'
+        db.alter_column(u'cities_light_city', 'slug', self.gf('autoslug.fields.AutoSlugField')(unique_with=(), max_length=50, populate_from='name_ascii'))
+
+        # Changing field 'Region.slug'
+        db.alter_column(u'cities_light_region', 'slug', self.gf('autoslug.fields.AutoSlugField')(unique_with=(), max_length=50, populate_from='name_ascii'))
+
+    def backwards(self, orm):
+
+        # Changing field 'Country.slug'
+        db.alter_column(u'cities_light_country', 'slug', self.gf('autoslug.fields.AutoSlugField')(max_length=50, unique_with=(), populate_from=None))
+        # Deleting field 'City.population'
+        db.delete_column(u'cities_light_city', 'population')
+
+        # Deleting field 'City.feature_code'
+        db.delete_column(u'cities_light_city', 'feature_code')
+
+
+        # Changing field 'City.slug'
+        db.alter_column(u'cities_light_city', 'slug', self.gf('autoslug.fields.AutoSlugField')(max_length=50, unique_with=(), populate_from=None))
+
+        # Changing field 'Region.slug'
+        db.alter_column(u'cities_light_region', 'slug', self.gf('autoslug.fields.AutoSlugField')(max_length=50, unique_with=(), populate_from=None))
+
+    models = {
+        u'cities_light.city': {
+            'Meta': {'unique_together': "(('region', 'name'),)", 'object_name': 'City'},
+            'alternate_names': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'}),
+            'country': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['cities_light.Country']"}),
+            'display_name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'feature_code': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '10', 'null': 'True', 'blank': 'True'}),
+            'geoname_id': ('django.db.models.fields.IntegerField', [], {'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'latitude': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '8', 'decimal_places': '5', 'blank': 'True'}),
+            'longitude': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '8', 'decimal_places': '5', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200', 'db_index': 'True'}),
+            'name_ascii': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '200', 'blank': 'True'}),
+            'population': ('django.db.models.fields.BigIntegerField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'region': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['cities_light.Region']", 'null': 'True', 'blank': 'True'}),
+            'search_names': ('cities_light.models.ToSearchTextField', [], {'default': "''", 'max_length': '4000', 'db_index': 'True', 'blank': 'True'}),
+            'slug': ('autoslug.fields.AutoSlugField', [], {'unique_with': '()', 'max_length': '50', 'populate_from': "'name_ascii'"})
+        },
+        u'cities_light.country': {
+            'Meta': {'object_name': 'Country'},
+            'alternate_names': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'}),
+            'code2': ('django.db.models.fields.CharField', [], {'max_length': '2', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'code3': ('django.db.models.fields.CharField', [], {'max_length': '3', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'continent': ('django.db.models.fields.CharField', [], {'max_length': '2', 'db_index': 'True'}),
+            'geoname_id': ('django.db.models.fields.IntegerField', [], {'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '200'}),
+            'name_ascii': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '200', 'blank': 'True'}),
+            'slug': ('autoslug.fields.AutoSlugField', [], {'unique_with': '()', 'max_length': '50', 'populate_from': "'name_ascii'"}),
+            'tld': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '5', 'blank': 'True'})
+        },
+        u'cities_light.region': {
+            'Meta': {'unique_together': "(('country', 'name'),)", 'object_name': 'Region'},
+            'alternate_names': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'}),
+            'country': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['cities_light.Country']"}),
+            'display_name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'geoname_code': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'geoname_id': ('django.db.models.fields.IntegerField', [], {'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200', 'db_index': 'True'}),
+            'name_ascii': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '200', 'blank': 'True'}),
+            'slug': ('autoslug.fields.AutoSlugField', [], {'unique_with': '()', 'max_length': '50', 'populate_from': "'name_ascii'"})
+        }
+    }
+
+    complete_apps = ['cities_light']

--- a/cities_light/models.py
+++ b/cities_light/models.py
@@ -168,6 +168,8 @@ class City(Base):
 
     region = models.ForeignKey(Region, blank=True, null=True)
     country = models.ForeignKey(Country)
+    population = models.BigIntegerField(null=True, blank=True, db_index=True)
+    feature_code = models.CharField(max_length=10, null=True, blank=True, db_index=True)
 
     class Meta:
         unique_together = (('region', 'name'),)


### PR DESCRIPTION
In applications where users search for a city, I think it would be useful to have feature_code and population available to improve search results.

Example: Search for "Berlin". Without population and feature_code, this will turn up

a.) every district of Berlin, Germany
b.) several very small towns in other countries named "Berlin"

With feature_code and population present, one can
1.) exclude (or even delete) results with feature code "PPLX" (because that's typically not what a user would expect)
2.) order results by population, so the larger cities will be displayed first

Note 1: I also removed CityForm from admin because it hides a lot of fields (which I find confusing) - feel free to ignore that if you don't like it
Note 2: you might want to double-check the migration in this patch (or provide your own version), since it somehow meddles with the AutoSlugField (frankly I don't know why, as I didn't change that in the model).
