### PR TITLE
Add support to filter countries before importing

### DIFF
--- a/cities_light/management/commands/cities_light.py
+++ b/cities_light/management/commands/cities_light.py
@@ -227,6 +227,10 @@ It is possible to force the import of files which weren't downloaded using the
 
     def country_import(self, items):
         try:
+            country_items_pre_import.send(sender=self, items=items)
+        except InvalidItems:
+            return
+        try:
             country = Country.objects.get(code2=items[0])
         except Country.DoesNotExist:
             if self.noinsert:

--- a/cities_light/signals.py
+++ b/cities_light/signals.py
@@ -29,6 +29,16 @@ region_items_pre_import
         cities_light.signals.region_items_pre_import.connect(
             filter_region_import)
 
+country_items_pre_import
+    Same as region_items_pre_import/city_items_pre_import, for example:
+
+        def filter_country_import(sender, items, **args):
+            if items[0].split('.')[0] not in ('FR', 'US', 'BE'):
+                raise cities_light.InvalidItems()
+
+        cities_light.signals.country_items_pre_import.connect(
+            filter_country_import)
+
 filter_non_cities()
     By default, this reciever is connected to city_items_pre_import, it raises
     InvalidItems if the row doesn't have PPL in its features (it's not a
@@ -41,10 +51,11 @@ import django.dispatch
 from .exceptions import *
 
 __all__ = ['city_items_pre_import', 'region_items_pre_import',
-    'filter_non_cities']
+           'country_items_pre_import', 'filter_non_cities']
 
 city_items_pre_import = django.dispatch.Signal(providing_args=['items'])
 region_items_pre_import = django.dispatch.Signal(providing_args=['items'])
+country_items_pre_import = django.dispatch.Signal(providing_args=['items'])
 
 
 def filter_non_cities(sender, items, **kwargs):


### PR DESCRIPTION
Signal country_items_pre_import created to filter
specific countries. Currently there are two signals to
filter cities and regions.
With this signal you can filter only import countries you wish.
