### PR TITLE
Fix ImportError when south not installed

### DIFF
--- a/cities_light/models.py
+++ b/cities_light/models.py
@@ -12,8 +12,6 @@ from django.utils.translation import ugettext_lazy as _
 
 from unidecode import unidecode
 
-from south.modelsinspector import add_introspection_rules
-
 import autoslug
 
 from .settings import *


### PR DESCRIPTION
Leftover south import triggers ImportError even when using Django migrations and south isn't installed.
