### PR TITLE
Fix: Alternate name file has 5 relevant columns

### DIFF
--- a/cities_light/management/commands/cities_light.py
+++ b/cities_light/management/commands/cities_light.py
@@ -394,7 +394,7 @@ It is possible to force the import of files which weren't downloaded using the
                 City: {},
             }
 
-        if len(items) > 4:
+        if len(items) > 5:
             # avoid shortnames, colloquial, and historic
             return
 


### PR DESCRIPTION
Check out http://download.geonames.org/export/dump/

This fixes #59
