### PR TITLE
Fixed copy-paste bug

### DIFF
--- a/cities_light/models.py
+++ b/cities_light/models.py
@@ -284,7 +284,7 @@ def filter_non_included_countries_region(sender, items, **kwargs):
 
     if items[0].split('.')[0] not in INCLUDE_COUNTRIES:
         raise InvalidItems()
-country_items_pre_import.connect(filter_non_included_countries_region)
+region_items_pre_import.connect(filter_non_included_countries_region)
 
 
 def filter_non_included_countries_city(sender, items, **kwargs):


### PR DESCRIPTION
``` 
% ./manage.py cities_light        
RAM used: 52500 kB Time: 0:00:00 Done: 100%|#######################################################################################################################################################################################|
Traceback (most recent call last):Done:   0%|                                                                                                                                                                                      |
  File "./manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/home/apkawa/.envs/tru/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 385, in execute_from_command_line
    utility.execute()
  File "/home/apkawa/.envs/tru/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 377, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/apkawa/.envs/tru/local/lib/python2.7/site-packages/django/core/management/base.py", line 288, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "/home/apkawa/.envs/tru/local/lib/python2.7/site-packages/django/core/management/base.py", line 338, in execute
    output = self.handle(*args, **options)
  File "/home/apkawa/.envs/tru/local/lib/python2.7/site-packages/cities_light/management/commands/cities_light.py", line 163, in handle
    self.region_import(items)
  File "/home/apkawa/.envs/tru/local/lib/python2.7/site-packages/cities_light/management/commands/cities_light.py", line 265, in region_import
    country_id = self._get_country_id(code2)
  File "/home/apkawa/.envs/tru/local/lib/python2.7/site-packages/cities_light/management/commands/cities_light.py", line 206, in _get_country_id
    self._country_codes[code2] = Country.objects.get(code2=code2).pk
  File "/home/apkawa/.envs/tru/local/lib/python2.7/site-packages/cacheops/query.py", line 424, in get
    return self.get_queryset().inplace().get(*args, **kwargs)
  File "/home/apkawa/.envs/tru/local/lib/python2.7/site-packages/cacheops/query.py", line 316, in get
    return qs._no_monkey.get(qs, *args, **kwargs)
  File "/home/apkawa/.envs/tru/local/lib/python2.7/site-packages/django/db/models/query.py", line 357, in get
    self.model._meta.object_name)
cities_light.models.DoesNotExist: Country matching query does not exist.
```
settings.py
```
CITIES_LIGHT_TRANSLATION_LANGUAGES = ['ru', 'en']
CITIES_LIGHT_INCLUDE_COUNTRIES = ['RU',]
```