### PR TITLE
Allow to customise models

### DIFF
--- a/cities_light/abstract_models.py
+++ b/cities_light/abstract_models.py
@@ -16,7 +16,8 @@ import autoslug
 from .settings import INDEX_SEARCH_NAMES, CITIES_LIGHT_APP_NAME
 
 
-__all__ = ['AbstractCountry', 'AbstractRegion', 'AbstractCity', 'CONTINENT_CHOICES']
+__all__ = ['AbstractCountry', 'AbstractRegion', 'AbstractCity',
+    'CONTINENT_CHOICES']
 
 
 CONTINENT_CHOICES = (
@@ -151,7 +152,8 @@ class AbstractCity(Base):
     longitude = models.DecimalField(max_digits=8, decimal_places=5,
         null=True, blank=True)
 
-    region = models.ForeignKey(CITIES_LIGHT_APP_NAME + '.Region', blank=True, null=True)
+    region = models.ForeignKey(CITIES_LIGHT_APP_NAME + '.Region', blank=True,
+                               null=True)
     country = models.ForeignKey(CITIES_LIGHT_APP_NAME + '.Country')
     population = models.BigIntegerField(null=True, blank=True, db_index=True)
     feature_code = models.CharField(max_length=10, null=True, blank=True,

--- a/cities_light/abstract_models.py
+++ b/cities_light/abstract_models.py
@@ -1,0 +1,170 @@
+
+
+import six
+import re
+
+from django.utils.encoding import python_2_unicode_compatible
+
+from django.utils.encoding import force_text
+from django.db import models
+from django.utils.translation import ugettext_lazy as _
+
+from unidecode import unidecode
+
+import autoslug
+
+from .settings import INDEX_SEARCH_NAMES, CITIES_LIGHT_APP_NAME
+
+
+__all__ = ['AbstractCountry', 'AbstractRegion', 'AbstractCity', 'CONTINENT_CHOICES']
+
+
+CONTINENT_CHOICES = (
+    ('OC', _('Oceania')),
+    ('EU', _('Europe')),
+    ('AF', _('Africa')),
+    ('NA', _('North America')),
+    ('AN', _('Antarctica')),
+    ('SA', _('South America')),
+    ('AS', _('Asia')),
+)
+
+ALPHA_REGEXP = re.compile('[\W_]+', re.UNICODE)
+
+
+def to_ascii(value):
+    if not six.PY3 and isinstance(value, str):
+        value = force_text(value)
+
+    return unidecode(value)
+
+
+def to_search(value):
+    """
+    Convert a string value into a string that is usable against
+    City.search_names.
+
+    For example, 'Paris Texas' would become 'paristexas'.
+    """
+
+    return ALPHA_REGEXP.sub('', to_ascii(value)).lower()
+
+
+@python_2_unicode_compatible
+class Base(models.Model):
+    """
+    Base model with boilerplate for all models.
+    """
+
+    name_ascii = models.CharField(max_length=200, blank=True, db_index=True)
+    slug = autoslug.AutoSlugField(populate_from='name_ascii')
+    geoname_id = models.IntegerField(null=True, blank=True, unique=True)
+    alternate_names = models.TextField(null=True, blank=True, default='')
+
+    class Meta:
+        abstract = True
+        ordering = ['name']
+
+    def __str__(self):
+        display_name = getattr(self, 'display_name', None)
+        if display_name:
+            return display_name
+        return self.name
+
+
+class AbstractCountry(Base):
+    """
+    Base Country model.
+    """
+
+    name = models.CharField(max_length=200, unique=True)
+
+    code2 = models.CharField(max_length=2, null=True, blank=True, unique=True)
+    code3 = models.CharField(max_length=3, null=True, blank=True, unique=True)
+    continent = models.CharField(max_length=2, db_index=True,
+        choices=CONTINENT_CHOICES)
+    tld = models.CharField(max_length=5, blank=True, db_index=True)
+    phone = models.CharField(max_length=20, null=True)
+
+    class Meta(Base.Meta):
+        verbose_name_plural = _('countries')
+        abstract = True
+
+
+class AbstractRegion(Base):
+    """
+    Base Region/State model.
+    """
+
+    name = models.CharField(max_length=200, db_index=True)
+    display_name = models.CharField(max_length=200)
+    geoname_code = models.CharField(max_length=50, null=True, blank=True,
+        db_index=True)
+
+    country = models.ForeignKey(CITIES_LIGHT_APP_NAME + '.Country')
+
+    class Meta(Base.Meta):
+        unique_together = (('country', 'name'), ('country', 'slug'))
+        verbose_name = _('region/state')
+        verbose_name_plural = _('regions/states')
+        abstract = True
+
+    def get_display_name(self):
+        return '%s, %s' % (self.name, self.country.name)
+
+
+class ToSearchTextField(models.TextField):
+    """
+    Trivial TextField subclass that passes values through to_search
+    automatically.
+    """
+    def get_prep_lookup(self, lookup_type, value):
+        """
+        Return the value passed through to_search().
+        """
+        value = super(ToSearchTextField, self).get_prep_lookup(lookup_type,
+            value)
+        return to_search(value)
+
+    def south_field_triple(self):
+        "Returns a suitable description of this field for South."
+        from south.modelsinspector import introspector
+        field_class = self.__class__.__module__ + "." + self.__class__.__name__
+        args, kwargs = introspector(self)
+        # That's our definition!
+        return (field_class, args, kwargs)
+
+
+class AbstractCity(Base):
+    """
+    Base City model.
+    """
+
+    name = models.CharField(max_length=200, db_index=True)
+    display_name = models.CharField(max_length=200)
+
+    search_names = ToSearchTextField(max_length=4000,
+        db_index=INDEX_SEARCH_NAMES, blank=True, default='')
+
+    latitude = models.DecimalField(max_digits=8, decimal_places=5,
+        null=True, blank=True)
+    longitude = models.DecimalField(max_digits=8, decimal_places=5,
+        null=True, blank=True)
+
+    region = models.ForeignKey(CITIES_LIGHT_APP_NAME + '.Region', blank=True, null=True)
+    country = models.ForeignKey(CITIES_LIGHT_APP_NAME + '.Country')
+    population = models.BigIntegerField(null=True, blank=True, db_index=True)
+    feature_code = models.CharField(max_length=10, null=True, blank=True,
+                                    db_index=True)
+
+    class Meta(Base.Meta):
+        unique_together = (('region', 'name'), ('region', 'slug'))
+        verbose_name_plural = _('cities')
+        abstract = True
+
+    def get_display_name(self):
+        if self.region_id:
+            return '%s, %s, %s' % (self.name, self.region.name,
+                self.country.name)
+        else:
+            return '%s, %s' % (self.name, self.country.name)

--- a/cities_light/admin.py
+++ b/cities_light/admin.py
@@ -7,6 +7,7 @@ from django.contrib.admin.views.main import ChangeList
 
 from .forms import *
 from .settings import *
+from .abstract_models import to_search
 from .loading import get_cities_model
 
 Country = get_cities_model('Country')

--- a/cities_light/admin.py
+++ b/cities_light/admin.py
@@ -6,8 +6,12 @@ from django.contrib import admin
 from django.contrib.admin.views.main import ChangeList
 
 from .forms import *
-from .models import *
 from .settings import *
+from .loading import get_cities_model
+
+Country = get_cities_model('Country')
+Region = get_cities_model('Region')
+City = get_cities_model('City')
 
 
 class CountryAdmin(admin.ModelAdmin):

--- a/cities_light/contrib/ajax_selects_lookups.py
+++ b/cities_light/contrib/ajax_selects_lookups.py
@@ -10,7 +10,11 @@ Register the lookups in settings.AJAX_LOOKUP_CHANNELS, add::
 from ajax_select import LookupChannel
 from django.db.models import Q
 
-from ..models import *
+from ..loading import get_cities_model
+
+Country = get_cities_model('Country')
+Region = get_cities_model('Region')
+City = get_cities_model('City')
 
 
 class StandardLookupChannel(LookupChannel):

--- a/cities_light/contrib/autocompletes.py
+++ b/cities_light/contrib/autocompletes.py
@@ -1,6 +1,10 @@
-from ..models import Country, Region, City
+from ..loading import get_cities_model
 
 import autocomplete_light
+
+Country = get_cities_model('Country')
+Region = get_cities_model('Region')
+City = get_cities_model('City')
 
 
 class CityAutocomplete(autocomplete_light.AutocompleteModelBase):

--- a/cities_light/contrib/restframework.py
+++ b/cities_light/contrib/restframework.py
@@ -29,7 +29,11 @@ from djangorestframework.views import ModelView, ListModelView
 from djangorestframework.mixins import InstanceMixin, ReadModelMixin
 from djangorestframework.resources import ModelResource
 
-from ..models import Country, Region, City
+from ..loading import get_cities_model
+
+Country = get_cities_model('Country')
+Region = get_cities_model('Region')
+City = get_cities_model('City')
 
 
 class CityResource(ModelResource):

--- a/cities_light/contrib/restframework2.py
+++ b/cities_light/contrib/restframework2.py
@@ -26,7 +26,11 @@ try:
 except ImportError:
     from django.conf.urls import patterns, url, include
 
-from ..models import Country, Region, City
+from ..loading import get_cities_model
+
+Country = get_cities_model('Country')
+Region = get_cities_model('Region')
+City = get_cities_model('City')
 
 
 class CitySerializer(HyperlinkedModelSerializer):

--- a/cities_light/contrib/restframework3.py
+++ b/cities_light/contrib/restframework3.py
@@ -26,7 +26,11 @@ try:
 except ImportError:
     from django.conf.urls import patterns, url, include
 
-from ..models import Country, Region, City
+from ..loading import get_cities_model
+
+Country = get_cities_model('Country')
+Region = get_cities_model('Region')
+City = get_cities_model('City')
 
 
 class CitySerializer(HyperlinkedModelSerializer):

--- a/cities_light/forms.py
+++ b/cities_light/forms.py
@@ -2,7 +2,11 @@ from __future__ import unicode_literals
 
 from django import forms
 
-from .models import Country, Region, City
+from .loading import get_cities_model
+
+Country = get_cities_model('Country')
+Region = get_cities_model('Region')
+City = get_cities_model('City')
 
 __all__ = ['CountryForm', 'RegionForm', 'CityForm']
 

--- a/cities_light/loading.py
+++ b/cities_light/loading.py
@@ -1,0 +1,17 @@
+import django
+from .settings import CITIES_LIGHT_APP_NAME
+
+
+if django.VERSION < (1, 7):
+    from django.db.models import get_model
+else:
+    from django.apps import apps
+    get_model = apps.get_model
+
+
+def get_cities_model(model_name, *args, **kwargs):
+    """
+    Returns cities model, either default either customised, depending on
+    ``settings.CITIES_LIGHT_APP_NAME``.
+    """
+    return get_model(CITIES_LIGHT_APP_NAME, model_name, *args, **kwargs)

--- a/cities_light/management/commands/cities_light.py
+++ b/cities_light/management/commands/cities_light.py
@@ -24,9 +24,13 @@ from ...vendor import progressbar
 
 from ...exceptions import *
 from ...signals import *
-from ...models import *
 from ...settings import *
 from ...geonames import Geonames
+from ...loading import get_cities_model
+
+Country = get_cities_model('Country')
+Region = get_cities_model('Region')
+City = get_cities_model('City')
 
 
 class MemoryUsageWidget(progressbar.Widget):
@@ -246,6 +250,9 @@ It is possible to force the import of files which weren't downloaded using the
         if items[16]:
             country.geoname_id = items[16]
 
+        country_items_post_import.send(sender=self, instance=country,
+            items=items)
+
         self.save(country)
 
     def region_import(self, items):
@@ -289,6 +296,10 @@ It is possible to force the import of files which weren't downloaded using the
             region.name_ascii = items[2]
 
         region.geoname_id = items[3]
+
+        region_items_post_import.send(sender=self, instance=region,
+            items=items)
+
         self.save(region)
 
     def city_import(self, items):
@@ -375,6 +386,9 @@ It is possible to force the import of files which weren't downloaded using the
             # city may have been added manually
             city.geoname_id = items[0]
             save = True
+
+        city_items_post_import.send(sender=self, instance=city,
+            items=items, save=save)
 
         if save:
             self.save(city)

--- a/cities_light/models.py
+++ b/cities_light/models.py
@@ -1,304 +1,100 @@
+"""
+By default, all models are taken from this package.
+But it is possible to customise these models to add some fields.
+For such purpose cities_light models are defined as abstract (without customisation
+they all inherit abstract versions without changes).
+
+Steps to customise cities_light models
+======================================
+
+- Define **all** of cities abstract models in your app:
+    .. code:: python
+
+        # yourapp/models.py
+
+        from cities_light.abstract_models import (AbstractCity, AbstractRegion,
+            AbstractCountry)
+        from cities_light.receivers import connect_default_signals
 
 
-import six
-import re
+        class Country(AbstractCountry):
+            pass
+        connect_default_signals(Country)
 
-from django.utils.encoding import python_2_unicode_compatible
+        class Region(AbstractRegion):
+            pass
+        connect_default_signals(Region)
 
-from django.utils.encoding import force_text
-from django.db.models import signals
-from django.db import models
-from django.utils.translation import ugettext_lazy as _
 
-from unidecode import unidecode
+        class City(AbstractCity):
+            timezone = models.CharField(max_length=40)
+        connect_default_signals(City)
 
-import autoslug
+- Add post import processing to you model *[optional]*:
+    .. code:: python
 
-from .settings import *
+        import cities_light
+
+        def set_city_fields(sender, instance, items, **kwargs):
+            instance.timezone_name = items[17]
+        cities_light.signals.city_items_post_import.connect(set_city_fields)
+
+- Define settings.py:
+    .. code:: python
+
+        INSTALLED_APPS = [
+            # ...
+            'cities_light',
+            'yourapp',
+        ]
+
+        CITIES_LIGHT_APP_NAME = 'yourapp'
+
+- Create tables:
+    .. code::
+
+        python manage.py syncdb
+
+That's all!
+
+**Notes**:
+    - model names can't be modified, i.e. you have to use exactly
+      City, Country, Region names and not MyCity, MyCountry, MyRegion.
+    - Connect default signals for every custom model by calling
+      ``connect_default_signals`` (or not, if you don't want to trigger
+      default signals).
+    - if in further versions of cities_light abstract models will be
+      updated (some fields will be added/removed), you have to deal with
+      migrations by yourself, as models are on your own now.
+"""
+
+# some imports are present for backwards compatibility and migration process
+from .abstract_models import (AbstractCountry, AbstractRegion, AbstractCity,
+    ToSearchTextField, CONTINENT_CHOICES, to_search, to_ascii)
 from .signals import *
-from .exceptions import *
+from .receivers import *
+from .settings import *
 
-
-__all__ = ['Country', 'Region', 'City', 'CONTINENT_CHOICES', 'to_search',
-    'to_ascii', 'filter_non_cities', 'filter_non_included_countries_country',
+__all__ = ['CONTINENT_CHOICES', 'to_search', 'to_ascii', 'filter_non_cities',
+    'filter_non_included_countries_country',
     'filter_non_included_countries_region',
     'filter_non_included_countries_city']
 
-ALPHA_REGEXP = re.compile('[\W_]+', re.UNICODE)
+if CITIES_LIGHT_APP_NAME == DEFAULT_APP_NAME:
+    class Country(AbstractCountry):
+        pass
+    connect_default_signals(Country)
 
-CONTINENT_CHOICES = (
-    ('OC', _('Oceania')),
-    ('EU', _('Europe')),
-    ('AF', _('Africa')),
-    ('NA', _('North America')),
-    ('AN', _('Antarctica')),
-    ('SA', _('South America')),
-    ('AS', _('Asia')),
-)
+    __all__.append('Country')
 
+    class Region(AbstractRegion):
+        pass
+    connect_default_signals(Region)
 
-def to_ascii(value):
-    if not six.PY3 and isinstance(value, str):
-        value = force_text(value)
+    __all__.append('Region')
 
-    return unidecode(value)
+    class City(AbstractCity):
+        pass
+    connect_default_signals(City)
 
-
-def to_search(value):
-    """
-    Convert a string value into a string that is usable against
-    City.search_names.
-
-    For example, 'Paris Texas' would become 'paristexas'.
-    """
-
-    return ALPHA_REGEXP.sub('', to_ascii(value)).lower()
-
-
-def set_name_ascii(sender, instance=None, **kwargs):
-    """
-    Signal reciever that sets instance.name_ascii from instance.name.
-
-    Ascii versions of names are often useful for autocompletes and search.
-    """
-    name_ascii = to_ascii(instance.name)
-
-    if not name_ascii.strip():
-        return
-
-    if name_ascii and not instance.name_ascii:
-        instance.name_ascii = to_ascii(instance.name)
-
-
-def set_display_name(sender, instance=None, **kwargs):
-    """
-    Set instance.display_name to instance.get_display_name(), avoid spawning
-    queries during __str__().
-    """
-    instance.display_name = instance.get_display_name()
-
-
-@python_2_unicode_compatible
-class Base(models.Model):
-    """
-    Base model with boilerplate for all models.
-    """
-
-    name_ascii = models.CharField(max_length=200, blank=True, db_index=True)
-    slug = autoslug.AutoSlugField(populate_from='name_ascii')
-    geoname_id = models.IntegerField(null=True, blank=True, unique=True)
-    alternate_names = models.TextField(null=True, blank=True, default='')
-
-    class Meta:
-        abstract = True
-        ordering = ['name']
-
-    def __str__(self):
-        display_name = getattr(self, 'display_name', None)
-        if display_name:
-            return display_name
-        return self.name
-
-
-class Country(Base):
-    """
-    Country model.
-    """
-
-    name = models.CharField(max_length=200, unique=True)
-
-    code2 = models.CharField(max_length=2, null=True, blank=True, unique=True)
-    code3 = models.CharField(max_length=3, null=True, blank=True, unique=True)
-    continent = models.CharField(max_length=2, db_index=True,
-        choices=CONTINENT_CHOICES)
-    tld = models.CharField(max_length=5, blank=True, db_index=True)
-    phone = models.CharField(max_length=20, null=True)
-
-    class Meta(Base.Meta):
-        verbose_name_plural = _('countries')
-signals.pre_save.connect(set_name_ascii, sender=Country)
-
-
-class Region(Base):
-    """
-    Region/State model.
-    """
-
-    name = models.CharField(max_length=200, db_index=True)
-    display_name = models.CharField(max_length=200)
-    geoname_code = models.CharField(max_length=50, null=True, blank=True,
-        db_index=True)
-
-    country = models.ForeignKey(Country)
-
-    class Meta(Base.Meta):
-        unique_together = (('country', 'name'), ('country', 'slug'))
-        verbose_name = _('region/state')
-        verbose_name_plural = _('regions/states')
-
-    def get_display_name(self):
-        return '%s, %s' % (self.name, self.country.name)
-
-signals.pre_save.connect(set_name_ascii, sender=Region)
-signals.pre_save.connect(set_display_name, sender=Region)
-
-
-class ToSearchTextField(models.TextField):
-    """
-    Trivial TextField subclass that passes values through to_search
-    automatically.
-    """
-    def get_prep_lookup(self, lookup_type, value):
-        """
-        Return the value passed through to_search().
-        """
-        value = super(ToSearchTextField, self).get_prep_lookup(lookup_type,
-            value)
-        return to_search(value)
-
-    def south_field_triple(self):
-        "Returns a suitable description of this field for South."
-        from south.modelsinspector import introspector
-        field_class = self.__class__.__module__ + "." + self.__class__.__name__
-        args, kwargs = introspector(self)
-        # That's our definition!
-        return (field_class, args, kwargs)
-
-
-class City(Base):
-    """
-    City model.
-    """
-
-    name = models.CharField(max_length=200, db_index=True)
-    display_name = models.CharField(max_length=200)
-
-    search_names = ToSearchTextField(max_length=4000,
-        db_index=INDEX_SEARCH_NAMES, blank=True, default='')
-
-    latitude = models.DecimalField(max_digits=8, decimal_places=5,
-        null=True, blank=True)
-    longitude = models.DecimalField(max_digits=8, decimal_places=5,
-        null=True, blank=True)
-
-    region = models.ForeignKey(Region, blank=True, null=True)
-    country = models.ForeignKey(Country)
-    population = models.BigIntegerField(null=True, blank=True, db_index=True)
-    feature_code = models.CharField(max_length=10, null=True, blank=True,
-                                    db_index=True)
-
-    class Meta(Base.Meta):
-        unique_together = (('region', 'name'), ('region', 'slug'))
-        verbose_name_plural = _('cities')
-
-    def get_display_name(self):
-        if self.region_id:
-            return '%s, %s, %s' % (self.name, self.region.name,
-                self.country.name)
-        else:
-            return '%s, %s' % (self.name, self.country.name)
-signals.pre_save.connect(set_name_ascii, sender=City)
-signals.pre_save.connect(set_display_name, sender=City)
-
-
-def city_country(sender, instance, **kwargs):
-    if instance.region_id and not instance.country_id:
-        instance.country = instance.region.country
-signals.pre_save.connect(city_country, sender=City)
-
-
-def city_search_names(sender, instance, **kwargs):
-    search_names = []
-
-    country_names = [instance.country.name]
-    if instance.country.alternate_names:
-        country_names += instance.country.alternate_names.split(',')
-
-    city_names = [instance.name]
-    if instance.alternate_names:
-        city_names += instance.alternate_names.split(',')
-
-    if instance.region_id:
-        region_names = [instance.region.name]
-        if instance.region.alternate_names:
-            region_names += instance.region.alternate_names.split(',')
-
-    for city_name in city_names:
-        for country_name in country_names:
-            name = to_search(city_name + country_name)
-            if name not in search_names:
-                search_names.append(name)
-
-            if instance.region_id:
-                for region_name in region_names:
-                    name = to_search(city_name + region_name + country_name)
-                    if name not in search_names:
-                        search_names.append(name)
-
-    instance.search_names = ' '.join(search_names)
-signals.pre_save.connect(city_search_names, sender=City)
-
-
-def filter_non_cities(sender, items, **kwargs):
-    """
-    Reports non populated places as invalid.
-
-    By default, this reciever is connected to
-    :py:func:`~cities_light.signals.city_items_pre_import`, it raises
-    :py:class:`~cities_light.exceptions.InvalidItems` if the row doesn't have
-    PPL in its features (it's not a populated place).
-    """
-    if 'PPL' not in items[7]:
-        raise InvalidItems()
-city_items_pre_import.connect(filter_non_cities)
-
-
-def filter_non_included_countries_country(sender, items, **kwargs):
-    """
-    Exclude any **country** which country must not be included.
-
-    This is slot is connected to the
-    :py:func:`~cities_light.signals.country_items_pre_import` signal and does
-    nothing by default.  To enable it, set the
-    :py:data:`~cities_light.settings.INCLUDE_COUNTRIES` setting.
-    """
-    if INCLUDE_COUNTRIES is None:
-        return
-
-    if items[0].split('.')[0] not in INCLUDE_COUNTRIES:
-        raise InvalidItems()
-country_items_pre_import.connect(filter_non_included_countries_country)
-
-
-def filter_non_included_countries_region(sender, items, **kwargs):
-    """
-    Exclude any **region** which country must not be included.
-
-    This is slot is connected to the
-    :py:func:`~cities_light.signals.region_items_pre_import` signal and does
-    nothing by default.  To enable it, set the
-    :py:data:`~cities_light.settings.INCLUDE_COUNTRIES` setting.
-    """
-    if INCLUDE_COUNTRIES is None:
-        return
-
-    if items[0].split('.')[0] not in INCLUDE_COUNTRIES:
-        raise InvalidItems()
-country_items_pre_import.connect(filter_non_included_countries_region)
-
-
-def filter_non_included_countries_city(sender, items, **kwargs):
-    """
-    Exclude any **city** which country must not be included.
-
-    This is slot is connected to the
-    :py:func:`~cities_light.signals.city_items_pre_import` signal and does
-    nothing by default.  To enable it, set the
-    :py:data:`~cities_light.settings.INCLUDE_COUNTRIES` setting.
-    """
-    if INCLUDE_COUNTRIES is None:
-        return
-
-    if items[8].split('.')[0] not in INCLUDE_COUNTRIES:
-        raise InvalidItems()
-city_items_pre_import.connect(filter_non_included_countries_city)
+    __all__.append('City')

--- a/cities_light/models.py
+++ b/cities_light/models.py
@@ -1,8 +1,9 @@
 """
 By default, all models are taken from this package.
 But it is possible to customise these models to add some fields.
-For such purpose cities_light models are defined as abstract (without customisation
-they all inherit abstract versions without changes).
+For such purpose cities_light models are defined as abstract (without
+customisation they all inherit abstract versions automatically
+without changes).
 
 Steps to customise cities_light models
 ======================================
@@ -36,7 +37,7 @@ Steps to customise cities_light models
         import cities_light
 
         def set_city_fields(sender, instance, items, **kwargs):
-            instance.timezone_name = items[17]
+            instance.timezone = items[17]
         cities_light.signals.city_items_post_import.connect(set_city_fields)
 
 - Define settings.py:

--- a/cities_light/receivers.py
+++ b/cities_light/receivers.py
@@ -1,0 +1,143 @@
+from django.db.models import signals
+from .abstract_models import to_ascii, to_search
+from .settings import *
+from .signals import *
+from .exceptions import *
+
+
+def set_name_ascii(sender, instance=None, **kwargs):
+    """
+    Signal reciever that sets instance.name_ascii from instance.name.
+
+    Ascii versions of names are often useful for autocompletes and search.
+    """
+    name_ascii = to_ascii(instance.name)
+
+    if not name_ascii.strip():
+        return
+
+    if name_ascii and not instance.name_ascii:
+        instance.name_ascii = to_ascii(instance.name)
+
+
+def set_display_name(sender, instance=None, **kwargs):
+    """
+    Set instance.display_name to instance.get_display_name(), avoid spawning
+    queries during __str__().
+    """
+    instance.display_name = instance.get_display_name()
+
+
+def city_country(sender, instance, **kwargs):
+    if instance.region_id and not instance.country_id:
+        instance.country = instance.region.country
+
+
+def city_search_names(sender, instance, **kwargs):
+    search_names = []
+
+    country_names = [instance.country.name]
+    if instance.country.alternate_names:
+        country_names += instance.country.alternate_names.split(',')
+
+    city_names = [instance.name]
+    if instance.alternate_names:
+        city_names += instance.alternate_names.split(',')
+
+    if instance.region_id:
+        region_names = [instance.region.name]
+        if instance.region.alternate_names:
+            region_names += instance.region.alternate_names.split(',')
+
+    for city_name in city_names:
+        for country_name in country_names:
+            name = to_search(city_name + country_name)
+            if name not in search_names:
+                search_names.append(name)
+
+            if instance.region_id:
+                for region_name in region_names:
+                    name = to_search(city_name + region_name + country_name)
+                    if name not in search_names:
+                        search_names.append(name)
+
+    instance.search_names = ' '.join(search_names)
+
+
+def connect_default_signals(model_class):
+    """
+    Use this function to connect default signals to your custom model.
+    It is called automatically, if default cities_light models are used,
+    i.e. settings `CITIES_LIGHT_APP_NAME` is not changed.
+    """
+    if 'Country' in model_class.__name__:
+        signals.pre_save.connect(set_name_ascii, sender=model_class)
+    if 'Region' in model_class.__name__:
+        signals.pre_save.connect(set_name_ascii, sender=model_class)
+        signals.pre_save.connect(set_display_name, sender=model_class)
+    if 'City' in model_class.__name__:
+        signals.pre_save.connect(set_name_ascii, sender=model_class)
+        signals.pre_save.connect(set_display_name, sender=model_class)
+        signals.pre_save.connect(city_country, sender=model_class)
+        signals.pre_save.connect(city_search_names, sender=model_class)
+
+
+def filter_non_cities(sender, items, **kwargs):
+    """
+    Reports non populated places as invalid.
+    By default, this reciever is connected to
+    :py:func:`~cities_light.signals.city_items_pre_import`, it raises
+    :py:class:`~cities_light.exceptions.InvalidItems` if the row doesn't have
+    PPL in its features (it's not a populated place).
+    """
+    if 'PPL' not in items[7]:
+        raise InvalidItems()
+city_items_pre_import.connect(filter_non_cities)
+
+
+def filter_non_included_countries_country(sender, items, **kwargs):
+    """
+    Exclude any **country** which country must not be included.
+    This is slot is connected to the
+    :py:func:`~cities_light.signals.country_items_pre_import` signal and does
+    nothing by default.  To enable it, set the
+    :py:data:`~cities_light.settings.INCLUDE_COUNTRIES` setting.
+    """
+    if INCLUDE_COUNTRIES is None:
+        return
+
+    if items[0].split('.')[0] not in INCLUDE_COUNTRIES:
+        raise InvalidItems()
+country_items_pre_import.connect(filter_non_included_countries_country)
+
+
+def filter_non_included_countries_region(sender, items, **kwargs):
+    """
+    Exclude any **region** which country must not be included.
+    This is slot is connected to the
+    :py:func:`~cities_light.signals.region_items_pre_import` signal and does
+    nothing by default.  To enable it, set the
+    :py:data:`~cities_light.settings.INCLUDE_COUNTRIES` setting.
+    """
+    if INCLUDE_COUNTRIES is None:
+        return
+
+    if items[0].split('.')[0] not in INCLUDE_COUNTRIES:
+        raise InvalidItems()
+region_items_pre_import.connect(filter_non_included_countries_region)
+
+
+def filter_non_included_countries_city(sender, items, **kwargs):
+    """
+    Exclude any **city** which country must not be included.
+    This is slot is connected to the
+    :py:func:`~cities_light.signals.city_items_pre_import` signal and does
+    nothing by default.  To enable it, set the
+    :py:data:`~cities_light.settings.INCLUDE_COUNTRIES` setting.
+    """
+    if INCLUDE_COUNTRIES is None:
+        return
+
+    if items[8].split('.')[0] not in INCLUDE_COUNTRIES:
+        raise InvalidItems()
+city_items_pre_import.connect(filter_non_included_countries_city)

--- a/cities_light/settings.py
+++ b/cities_light/settings.py
@@ -65,6 +65,16 @@ because it's probably project specific.
     it is **not** MySQL), then this should be set to True. You might have to
     override this setting with ``settings.CITIES_LIGHT_INDEX_SEARCH_NAMES`` if
     using several databases for your project.
+
+.. py:data:: CITIES_LIGHT_APP_NAME
+
+    Modify it only if you want to define your custom cities models, that
+    are inherited from abstract models of this package.
+    It must be equal to app name, where custom models are defined.
+    For example, if they are in geo/models.py, then set
+    ``settings.CITIES_LIGHT_APP_NAME = 'geo'``.
+    Note: you can't define one custom model, you have to define all of
+    cities_light models, even if you want to modify only one.
 """
 from __future__ import unicode_literals
 
@@ -74,7 +84,8 @@ from django.conf import settings
 
 __all__ = ['COUNTRY_SOURCES', 'REGION_SOURCES', 'CITY_SOURCES',
     'TRANSLATION_LANGUAGES', 'TRANSLATION_SOURCES', 'SOURCES', 'DATA_DIR',
-    'INDEX_SEARCH_NAMES', 'INCLUDE_COUNTRIES']
+    'INDEX_SEARCH_NAMES', 'INCLUDE_COUNTRIES', 'DEFAULT_APP_NAME',
+    'CITIES_LIGHT_APP_NAME']
 
 COUNTRY_SOURCES = getattr(settings, 'CITIES_LIGHT_COUNTRY_SOURCES',
     ['http://download.geonames.org/export/dump/countryInfo.txt'])
@@ -103,3 +114,7 @@ if INDEX_SEARCH_NAMES is None:
     for database in list(settings.DATABASES.values()):
         if 'mysql' in database['ENGINE'].lower():
             INDEX_SEARCH_NAMES = False
+
+DEFAULT_APP_NAME = 'cities_light'
+CITIES_LIGHT_APP_NAME = getattr(settings, 'CITIES_LIGHT_APP_NAME',
+    DEFAULT_APP_NAME)

--- a/cities_light/signals.py
+++ b/cities_light/signals.py
@@ -29,14 +29,47 @@ Signals for this application.
 
     Same as :py:data:`~cities_light.signals.region_items_pre_import` and
     :py:data:`cities_light.signals.city_items_pre_import`.
+
+.. py:data:: city_items_post_import
+
+    Emited by city_import() in the cities_light command for each row parsed in
+    the data file, right before saving City object. Along with City instance
+    it pass items with geonames data. Will be useful, if you define custom
+    cities models with ``settings.CITIES_LIGHT_APP_NAME``.
+
+    Example::
+
+        import cities_light
+
+        def process_city_import(sender, instance, items, **kwargs):
+            instance.timezone = items[17]
+
+        cities_light.signals.city_items_post_import.connect(process_city_import)
+
+.. py:data:: region_items_post_import
+
+    Same as :py:data:`~cities_light.signals.city_items_post_import`.
+
+.. py:data:: country_items_post_import
+
+    Same as :py:data:`~cities_light.signals.region_items_post_import` and
+    :py:data:`cities_light.signals.city_items_post_import`.
 """
 from __future__ import unicode_literals
 
 import django.dispatch
 
 __all__ = ['city_items_pre_import', 'region_items_pre_import',
-           'country_items_pre_import']
+           'country_items_pre_import', 'city_items_post_import',
+           'region_items_post_import', 'country_items_post_import']
 
 city_items_pre_import = django.dispatch.Signal(providing_args=['items'])
 region_items_pre_import = django.dispatch.Signal(providing_args=['items'])
 country_items_pre_import = django.dispatch.Signal(providing_args=['items'])
+
+city_items_post_import = django.dispatch.Signal(
+    providing_args=['instance', 'items'])
+region_items_post_import = django.dispatch.Signal(
+    providing_args=['instance', 'items'])
+country_items_post_import = django.dispatch.Signal(
+    providing_args=['instance', 'items'])


### PR DESCRIPTION
This package looks great and it got mostly everything that is needed for me, so i not use original [django-cities](https://github.com/coderholic/django-cities) package. Thanks for it!

I need a little customisation of the models, i.e. add some fields (concretely fields `City.timezone` and `Country.currency` to be filled from geonames database).
One way to do it is to fork this package and support it by my own.
Another way is to add these fields to default models of this package.
Both ways **not** looks great, so maybe we can provide customisation process, so everyone can add any fields that they need. And if default models is enough - just skip any customisation, it works as it worked (previous users also shouldn't face any errors).

To achieve this, we define our models as abstract and provide special settings to indicate, that we want/don't want to customise models. If not - abstract models become real automatically, and if yes - we subclass abstract models and continue.

This patch is implementation of such process. Look at docstring in [models.py](https://github.com/st4lk/django-cities-light/blob/abstract/cities_light/models.py) for more details.
It provide more complexity to package, but i think it will be useful.
