### PR TITLE
Fix django 1.8 compact in admin

### DIFF
--- a/cities_light/admin.py
+++ b/cities_light/admin.py
@@ -61,13 +61,13 @@ admin.site.register(Region, RegionAdmin)
 
 
 class CityChangeList(ChangeList):
-    def get_query_set(self, request):
+    def get_queryset(self, request):
         if 'q' in list(request.GET.keys()):
             request.GET = copy(request.GET)
             request.GET['q'] = to_search(request.GET['q'])
-        return super(CityChangeList, self).get_query_set(request)
-    # Django 1.8 compat
-    get_queryset = get_query_set
+        return super(CityChangeList, self).get_queryset(request)
+    # Django <1.8 compat
+    get_query_set = get_queryset
 
 
 class CityAdmin(admin.ModelAdmin):


### PR DESCRIPTION
In Django 1.8 "get_query_set" method was removed.
```
File "/usr/local/opt/pyenv/versions/***/lib/python2.7/site-packages/cities_light/admin.py", line 70, in get_query_set
    return super(CityChangeList, self).get_query_set(request)
AttributeError: 'super' object has no attribute 'get_query_set'
```