### PR TITLE
Add setting for more granular city feature code filtering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
   - pip install https://github.com/dcramer/pyflakes/tarball/master
   - python setup.py install
 before_script:
-  - "pep8 --ignore=E402,E124,E128 --exclude=tests,south_migrations,migrations,vendor cities_light"
+  - "pep8 --ignore=E402,E124,E128 --exclude=tests,south_migrations,migrations cities_light"
   - mysql -e 'create database cities_light_test;'
   - psql -c 'create database cities_light_test;' -U postgres
 script:

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
     :target: http://travis-ci.org/yourlabs/django-cities-light
 .. image:: https://pypip.in/d/django-cities-light/badge.png
     :target: https://crate.io/packages/django-cities-light
-.. image:: https://pypip.in/v/django-cities-light/badge.png   
+.. image:: https://pypip.in/v/django-cities-light/badge.png
     :target: https://crate.io/packages/django-cities-light
 
 django-cities-light -- *Simple django-cities alternative*
@@ -22,9 +22,9 @@ database, you should use
 `django-cities
 <https://github.com/coderholic/django-cities>`_.
 
-Requirements: 
+Requirements:
 
-- Python 2.7 or 3.3, 
+- Python 2.7 or 3.3,
 - **Django >= 1.6 for django-cities-light 3.x.x**
 - or Django >= 1.4 <= 1.6 for django-cities-light 2.x.x
 - MySQL (better in 3.x.x) or PostgreSQL or SQLite.
@@ -56,6 +56,7 @@ Configure filters to exclude data you don't want, ie.::
 
     CITIES_LIGHT_TRANSLATION_LANGUAGES = ['fr', 'en']
     CITIES_LIGHT_INCLUDE_COUNTRIES = ['FR']
+    CITIES_LIGHT_INCLUDE_CITY_TYPES = ['PPL', 'PPLA', 'PPLA2', 'PPLA3', 'PPLA4', 'PPLC', 'PPLF', 'PPLG', 'PPLL', 'PPLR', 'PPLS', 'STLMT',]
 
 Now, run syncdb, it will only create tables for models that are not disabled::
 
@@ -64,7 +65,7 @@ Now, run syncdb, it will only create tables for models that are not disabled::
 Note that this project supports django-south. It is recommended that you use
 south too else you're on your own for migrations/upgrades.
 
-.. danger:: 
+.. danger::
 
    Since version 2.4.0, django-cities-light uses django
    migrations by default. This means that django-south users

--- a/cities_light/receivers.py
+++ b/cities_light/receivers.py
@@ -84,11 +84,11 @@ def connect_default_signals(model_class):
 
 def filter_non_cities(sender, items, **kwargs):
     """
-    Reports non populated places as invalid.
-    By default, this reciever is connected to
+    Exclude any **city** which feature code must not be included.
+    By default, this receiver is connected to
     :py:func:`~cities_light.signals.city_items_pre_import`, it raises
-    :py:class:`~cities_light.exceptions.InvalidItems` if the row doesn't have
-    PPL in its features (it's not a populated place).
+    :py:class:`~cities_light.exceptions.InvalidItems` if the row feature code
+    is not in the :py:data:`~cities_light.settings.INCLUDE_CITY_TYPES` setting.
     """
     if items[7] not in INCLUDE_CITY_TYPES:
         raise InvalidItems()

--- a/cities_light/receivers.py
+++ b/cities_light/receivers.py
@@ -90,7 +90,7 @@ def filter_non_cities(sender, items, **kwargs):
     :py:class:`~cities_light.exceptions.InvalidItems` if the row doesn't have
     PPL in its features (it's not a populated place).
     """
-    if 'PPL' not in items[7]:
+    if items[7] not in INCLUDE_CITY_TYPES:
         raise InvalidItems()
 city_items_pre_import.connect(filter_non_cities)
 

--- a/cities_light/settings.py
+++ b/cities_light/settings.py
@@ -84,7 +84,7 @@ from django.conf import settings
 
 __all__ = ['COUNTRY_SOURCES', 'REGION_SOURCES', 'CITY_SOURCES',
     'TRANSLATION_LANGUAGES', 'TRANSLATION_SOURCES', 'SOURCES', 'DATA_DIR',
-    'INDEX_SEARCH_NAMES', 'INCLUDE_COUNTRIES', 'DEFAULT_APP_NAME',
+    'INDEX_SEARCH_NAMES', 'INCLUDE_COUNTRIES', 'INCLUDE_CITY_TYPES', 'DEFAULT_APP_NAME',
     'CITIES_LIGHT_APP_NAME', 'ICountry', 'IRegion', 'ICity',
     'IAlternate']
 
@@ -107,6 +107,13 @@ DATA_DIR = getattr(settings, 'CITIES_LIGHT_DATA_DIR',
         os.path.dirname(os.path.realpath(__file__)), 'data')))
 
 INCLUDE_COUNTRIES = getattr(settings, 'CITIES_LIGHT_INCLUDE_COUNTRIES', None)
+
+INCLUDE_CITY_TYPES = getattr(
+    settings,
+    'CITIES_LIGHT_INCLUDE_CITY_TYPES',
+    ['PPL', 'PPLA', 'PPLA2', 'PPLA3', 'PPLA4', 'PPLC', 'PPLCH', 'PPLF',
+     'PPLG', 'PPLH', 'PPLL', 'PPLQ', 'PPLR', 'PPLS', 'PPLW', 'PPLX']
+)
 
 # MySQL doesn't support indexing TextFields
 INDEX_SEARCH_NAMES = getattr(settings, 'CITIES_LIGHT_INDEX_SEARCH_NAMES', None)

--- a/cities_light/settings.py
+++ b/cities_light/settings.py
@@ -123,8 +123,8 @@ INCLUDE_COUNTRIES = getattr(settings, 'CITIES_LIGHT_INCLUDE_COUNTRIES', None)
 INCLUDE_CITY_TYPES = getattr(
     settings,
     'CITIES_LIGHT_INCLUDE_CITY_TYPES',
-    ['PPL', 'PPLA', 'PPLA2', 'PPLA3', 'PPLA4', 'PPLC', 'PPLCH', 'PPLF',
-     'PPLG', 'PPLH', 'PPLL', 'PPLQ', 'PPLR', 'PPLS', 'PPLW', 'PPLX']
+    ['PPL', 'PPLA', 'PPLA2', 'PPLA3', 'PPLA4', 'PPLC',
+     'PPLF', 'PPLG', 'PPLL', 'PPLR', 'PPLS', 'STLMT']
 )
 
 # MySQL doesn't support indexing TextFields

--- a/cities_light/settings.py
+++ b/cities_light/settings.py
@@ -26,6 +26,16 @@ because it's probably project specific.
 
         CITIES_LIGHT_INCLUDE_COUNTRIES = ['FR', 'BE']
 
+.. py:data:: INCLUDE_CITY_TYPES
+
+    List of city feature codes to include. They are described at
+    http://www.geonames.org/export/codes.html, section "P city, village".
+
+        CITIES_LIGHT_INCLUDE_CITY_TYPES = [
+            'PPL', 'PPLA', 'PPLA2', 'PPLA3', 'PPLA4', 'PPLC',
+            'PPLF', 'PPLG', 'PPLL', 'PPLR', 'PPLS', 'STLMT',
+        ]
+
 .. py:data:: COUNTRY_SOURCES
 
     A list of urls to download country info from. Default is countryInfo.txt
@@ -84,9 +94,9 @@ from django.conf import settings
 
 __all__ = ['COUNTRY_SOURCES', 'REGION_SOURCES', 'CITY_SOURCES',
     'TRANSLATION_LANGUAGES', 'TRANSLATION_SOURCES', 'SOURCES', 'DATA_DIR',
-    'INDEX_SEARCH_NAMES', 'INCLUDE_COUNTRIES', 'INCLUDE_CITY_TYPES', 'DEFAULT_APP_NAME',
-    'CITIES_LIGHT_APP_NAME', 'ICountry', 'IRegion', 'ICity',
-    'IAlternate']
+    'INDEX_SEARCH_NAMES', 'INCLUDE_COUNTRIES', 'INCLUDE_CITY_TYPES',
+    'DEFAULT_APP_NAME', 'CITIES_LIGHT_APP_NAME',
+    'ICountry', 'IRegion', 'ICity', 'IAlternate']
 
 COUNTRY_SOURCES = getattr(settings, 'CITIES_LIGHT_COUNTRY_SOURCES',
     ['http://download.geonames.org/export/dump/countryInfo.txt'])
@@ -108,6 +118,8 @@ DATA_DIR = getattr(settings, 'CITIES_LIGHT_DATA_DIR',
 
 INCLUDE_COUNTRIES = getattr(settings, 'CITIES_LIGHT_INCLUDE_COUNTRIES', None)
 
+# Feature codes are described in the "P city, village" section at
+# http://www.geonames.org/export/codes.html
 INCLUDE_CITY_TYPES = getattr(
     settings,
     'CITIES_LIGHT_INCLUDE_CITY_TYPES',


### PR DESCRIPTION
I propose an explicit setting to filter cities based on their feature code (and not just 'PPL' substring). Rationale:

1. Substring matching by 'PPL' is hardcoded and is not flexible
2. Several feature codes (like PPLH) have no sense for majority of users (abandoned, historic or destroyed places)
3. PPLX is not even a city (city district or suburb)
4. STLMT is a city

Below is the frequency of each feature code in each database, along with its description:

feature code | cities1000 | cities5000 | cities15000 | description
-------------|------------|------------|-------------|-----------------------------------------------
 PPL   *     |  69474     |  29852     |  14395      | populated place, a city, town, village
 PPLA  *     |  3481      |  3481      |  2341       | seat of a first-order administrative division
 PPLA2 *     |  15796     |  6476      |  3457       | seat of a second-order administrative division
 PPLA3 *     |  27278     |  4996      |  2215       | seat of a third-order administrative division
 PPLA4 *     |  26591     |  900       |  151        | seat of a fourth-order administrative division
 PPLC  *     |  242       |  242       |  242        | capital of a political entity
 PPLCH       |  0         |  0         |  0          | historical capital of a political entity
 PPLF  *     |  6         |  2         |  1          | farm village
 PPLG  *     |  14        |  14        |  14         | seat of government of a political entity
 PPLH        |  6         |  2         |  2          | a populated place that no longer exists
 PPLL  *     |  239       |  82        |  33         | populated locality
 PPLQ        |  19        |  6         |  3          | abandoned populated place
 PPLR  *     |  4         |  2         |  1          | religious populated place
 PPLS  *     |  12        |  6         |  4          | populated places
 PPLW        |  1         |  1         |  1          | destroyed populated place
 PPLX        |  2338      |  1310      |  622        | section of populated place
 STLMT *     |  1         |  0         |  0          | israeli settlement
-------------------------------------------------------------------------------------------------------

This pull request alters amount of imported records due to different set of default feature codes (`CITIES_LIGHT_INCLUDE_CITY_TYPES` only contains the codes marked by asterisks in the table above).