### PR TITLE
Drop LazyProgressBar, the patch is accepted upstream as of version 3.5.2

### DIFF
--- a/cities_light/management/commands/cities_light.py
+++ b/cities_light/management/commands/cities_light.py
@@ -31,25 +31,6 @@ from ...loading import get_cities_models
 Country, Region, City = get_cities_models()
 
 
-class LazyProgressBar(progressbar.ProgressBar):
-
-    """
-    Less CPU-intensive progressbar with lazy update.
-
-    Performs update() only if value increment is large enough to add more bars
-    to progressbar according to current terminal width.
-    """
-
-    def update(self, value=None):
-        try:
-            divisor = self.max_value / self.term_width
-            if value // divisor == self.previous_value // divisor:
-                return
-        except:
-            pass  # ignore any division errors
-        super(LazyProgressBar, self).update(value=value)
-
-
 class MemoryUsageWidget(progressbar.widgets.WidgetBase):
     def __call__(self, progress, data):
         if sys.platform != 'win32':
@@ -174,8 +155,10 @@ It is possible to force the import of files which weren't downloaded using the
                             continue
 
                 i = 0
-                progress = LazyProgressBar(max_value=geonames.num_lines(),
-                                           widgets=self.widgets).start()
+                progress = progressbar.ProgressBar(
+                    max_value=geonames.num_lines(),
+                    widgets=self.widgets
+                ).start()
 
                 for items in geonames.parse():
                     if url in CITY_SOURCES:
@@ -472,8 +455,10 @@ It is possible to force the import of files which weren't downloaded using the
             max += len(model_class_data.keys())
 
         i = 0
-        progress = LazyProgressBar(max_value=max,
-                                   widgets=self.widgets).start()
+        progress = progressbar.ProgressBar(
+            max_value=max,
+            widgets=self.widgets
+        ).start()
 
         for model_class, model_class_data in data.items():
             for geoname_id, geoname_data in model_class_data.items():

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         'six',
         'unidecode>=0.04.13',
         'django_autoslug',
-        'progressbar2>=3.5.1'
+        'progressbar2>=3.6.0'
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
My patch to reduce progressbar CPU usage is accepted upstream as of version 3.5.2, so LazyProgressBar subclass is not required anymore. Another line count reduction!