### PR TITLE
translation_items_pre_import signal

### DIFF
--- a/cities_light/management/commands/cities_light.py
+++ b/cities_light/management/commands/cities_light.py
@@ -420,6 +420,11 @@ It is possible to force the import of files which weren't downloaded using the
 
         connection.close()
 
+        try:
+            translation_items_pre_import.send(sender=self, items=items)
+        except InvalidItems:
+            return
+
         if len(items) > 5:
             # avoid shortnames, colloquial, and historic
             return

--- a/cities_light/signals.py
+++ b/cities_light/signals.py
@@ -30,6 +30,13 @@ Signals for this application.
     Same as :py:data:`~cities_light.signals.region_items_pre_import` and
     :py:data:`cities_light.signals.city_items_pre_import`.
 
+.. py:data:: translation_items_pre_import
+
+    Same as :py:data:`~cities_light.signals.region_items_pre_import` and
+    :py:data:`cities_light.signals.city_items_pre_import`.
+
+    Note: Be careful because of long runtime; it will be called VERY often.
+
 .. py:data:: city_items_post_import
 
     Emited by city_import() in the cities_light command for each row parsed in
@@ -61,11 +68,13 @@ import django.dispatch
 
 __all__ = ['city_items_pre_import', 'region_items_pre_import',
            'country_items_pre_import', 'city_items_post_import',
-           'region_items_post_import', 'country_items_post_import']
+           'region_items_post_import', 'country_items_post_import',
+           'translation_items_pre_import']
 
 city_items_pre_import = django.dispatch.Signal(providing_args=['items'])
 region_items_pre_import = django.dispatch.Signal(providing_args=['items'])
 country_items_pre_import = django.dispatch.Signal(providing_args=['items'])
+translation_items_pre_import = django.dispatch.Signal(providing_args=['items'])
 
 city_items_post_import = django.dispatch.Signal(
     providing_args=['instance', 'items'])


### PR DESCRIPTION
The signal is useful to import translation data in my own model. So you can save translations with the language code.

Alternatively i could implement a translation model completely if you are interested in. Maybe with an option to generate this model.