### PR TITLE
Speed improvements

### DIFF
--- a/cities_light/management/commands/cities_light.py
+++ b/cities_light/management/commands/cities_light.py
@@ -183,12 +183,12 @@ It is possible to force the import of files which weren't downloaded using the
                             del self._region_codes
                         self.translation_parse(items)
 
-                    reset_queries()
+                    # reset_queries()
 
-                    i += 1
-                    progress.update(i)
+                    # i += 1
+                    # progress.update(i)
 
-                    self._travis()
+                    # self._travis()
 
                 progress.finish()
 
@@ -418,7 +418,7 @@ It is possible to force the import of files which weren't downloaded using the
                 (City, {}),
             ))
 
-        connection.close()
+        # connection.close()
 
         if len(items) > 5:
             # avoid shortnames, colloquial, and historic

--- a/cities_light/management/commands/cities_light.py
+++ b/cities_light/management/commands/cities_light.py
@@ -156,7 +156,7 @@ It is possible to force the import of files which weren't downloaded using the
                     max_value=max_value,
                     widgets=self.widgets
                 ).start()
-                update_interval = max(int(max_value/1000), 1)
+                update_interval = max(int(max_value / 1000), 1)
 
                 for items in geonames.parse():
                     if url in CITY_SOURCES:

--- a/cities_light/management/commands/cities_light.py
+++ b/cities_light/management/commands/cities_light.py
@@ -17,9 +17,8 @@ except ImportError:
     import pickle
 
 from django.core.management.base import BaseCommand
-from django.db import transaction, reset_queries, IntegrityError
+from django.db import transaction, IntegrityError
 from django.utils.encoding import force_text
-from django.conf import settings
 
 import progressbar
 
@@ -172,9 +171,6 @@ It is possible to force the import of files which weren't downloaded using the
                         if getattr(self, '_region_codes', False):
                             del self._region_codes
                         self.translation_parse(items)
-
-                    if settings.DEBUG:
-                        reset_queries()
 
                     if 0 == i % update_interval:
                         progress.update(i)

--- a/cities_light/management/commands/cities_light.py
+++ b/cities_light/management/commands/cities_light.py
@@ -176,7 +176,7 @@ It is possible to force the import of files which weren't downloaded using the
                     if settings.DEBUG:
                         reset_queries()
 
-                    if i == 0 % update_interval:
+                    if 0 == i % update_interval:
                         progress.update(i)
                     i += 1
 

--- a/cities_light/management/commands/cities_light.py
+++ b/cities_light/management/commands/cities_light.py
@@ -395,11 +395,11 @@ It is possible to force the import of files which weren't downloaded using the
 
     def translation_parse(self, items):
         if not hasattr(self, 'translation_data'):
-            self.country_ids = list(Country.objects.values_list('geoname_id',
+            self.country_ids = set(Country.objects.values_list('geoname_id',
                 flat=True))
-            self.region_ids = list(Region.objects.values_list('geoname_id',
+            self.region_ids = set(Region.objects.values_list('geoname_id',
                 flat=True))
-            self.city_ids = list(City.objects.values_list('geoname_id',
+            self.city_ids = set(City.objects.values_list('geoname_id',
                 flat=True))
 
             self.translation_data = collections.OrderedDict((


### PR DESCRIPTION
I dont see any needs for the following functions, maybe you know why they should not be removed?
I tested only in dev enviroment (python 3.4.3, django 1.9), but could not see any changes in memory usage. 

- reset_queries() and connection.close() each saves ~100s.
- progress.update() does not work for me anyway, i dont know why, so it saves ~100s.
- _travis(), ok, but also saves ~100s.

All in all i reduced the runtime from about 700s to 300s. Quite a lot.