### PR TITLE
FIX get rid of deprecated-warning msg

### DIFF
--- a/cities_light/contrib/restframework3.py
+++ b/cities_light/contrib/restframework3.py
@@ -123,6 +123,6 @@ router.register(r'regions', RegionModelViewSet,
                 base_name='cities-light-api-region')
 
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^', include(router.urls)),
-)
+]


### PR DESCRIPTION
Django 1.9.x warns about a deprecation in Django 1.10.
This fixes it.