### PR TITLE
Issue # 136 Creating a ModelSerializer without either the 'fields' at…

### DIFF
--- a/cities_light/contrib/restframework3.py
+++ b/cities_light/contrib/restframework3.py
@@ -67,6 +67,7 @@ class CountrySerializer(HyperlinkedModelSerializer):
 
     class Meta:
         model = Country
+        fields = '__all__'
 
 
 class CitiesLightListModelViewSet(viewsets.ReadOnlyModelViewSet):


### PR DESCRIPTION
Creating a ModelSerializer without either the 'fields' attribute or the 'exclude' attribute has been deprecated since 3.3.0, and is now disallowed. Add an explicit fields = '__all__' to the CountrySerializer serializer. #136