### PR TITLE
Fix lack of support of Django 2.0 by django_autoslug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,18 +7,12 @@ matrix:
   - env: TOXENV=py35-djangodev-sqlite
   - env: TOXENV=py35-djangodev-mysql
   - env: TOXENV=py35-djangodev-postgresql
+  - env: TOXENV=py35-django110-mysql
 env:
   matrix:
-  - TOXENV=py27-django18-sqlite
-  - TOXENV=py27-django19-sqlite
-  - TOXENV=py27-django110-sqlite
   - TOXENV=py27-django111-sqlite
-  - TOXENV=py35-django18-sqlite
-  - TOXENV=py35-django19-sqlite
-  - TOXENV=py35-django110-sqlite
-  - TOXENV=py35-django110-mysql
-  - TOXENV=py35-django110-postgresql
   - TOXENV=py35-django111-sqlite
+  - TOXENV=py35-django20-sqlite
   - TOXENV=py35-djangodev-sqlite
   - TOXENV=py35-djangodev-mysql
   - TOXENV=py35-djangodev-postgresql

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         'six',
         'pytz',
         'unidecode>=0.04.13',
-        'django_autoslug',
+        'django-autoslug-iplweb==1.9.4.dev0',
         'progressbar2>=3.6.0'
     ],
     classifiers=[

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ sitepackages = False
 [base]
 deps =
     # recommended django version and other dependencies
-    Django>=1.8,<1.9
+    Django>=1.11a,<2.0
     django-ajax-selects==1.6.0
     djangorestframework==3.6.3
 
@@ -41,9 +41,9 @@ deps =
     mock
     coverage
     django-dbdiff>=0.4.0
-    djangorestframework==3.6.3
+    djangorestframework==3.7.7
     django-ajax-selects==1.6.0
-    git+https://github.com/jpic/django-autoslug.git@dj20#egg=django-autoslug
+    django-autoslug-iplweb==1.9.4.dev0
 
 [testenv]
 skipsdist = true
@@ -57,10 +57,8 @@ whitelist_externals =
     psql
 deps =
     {[test]deps}
-    django18: Django>=1.8,<1.9
-    django19: Django>=1.9,<1.10
-    django110: Django>=1.10,<1.11
-    django111: Django>=1.11a
+    django111: Django>=1.11a,<2.0
+    django20: Django>=2.0,<2.1
     djangodev: https://github.com/django/django/archive/master.tar.gz
     postgresql: psycopg2
     mysql: mysqlclient


### PR DESCRIPTION
Switched to `django-autoslug-iplweb` as a more up-to-date alternative to `django-autoslug`. The current `django-autoslug` dependency leads to lots of drama in a Django 2.0 project.