### PR TITLE
Import cities warnings

### DIFF
--- a/cities_light/management/commands/cities_light.py
+++ b/cities_light/management/commands/cities_light.py
@@ -395,9 +395,11 @@ It is possible to force the import of files which weren't downloaded using the
             force_update = True
         except City.DoesNotExist:
             try:
+                # check on duplicate by unique key
                 city = City.objects.get(name=items[ICity.name],
                                         region_id=region_id)
-                force_update = True
+                if city:
+                    return
             except City.DoesNotExist:
                 if self.noinsert:
                     return

--- a/cities_light/management/commands/cities_light.py
+++ b/cities_light/management/commands/cities_light.py
@@ -313,9 +313,10 @@ It is possible to force the import of files which weren't downloaded using the
         except InvalidItems:
             return
 
+        force_insert = False
+        force_update = False
+
         try:
-            force_insert = False
-            force_update = False
             region = Region.objects.get(geoname_id=items[IRegion.geonameid])
             force_update = True
         except Region.DoesNotExist:
@@ -371,17 +372,6 @@ It is possible to force the import of files which weren't downloaded using the
             return
 
         try:
-            force_insert = False
-            force_update = False
-            city = City.objects.get(geoname_id=items[ICity.geonameid])
-            force_update = True
-        except City.DoesNotExist:
-            if self.noinsert:
-                return
-            city = City(geoname_id=items[ICity.geonameid])
-            force_insert = True
-
-        try:
             country_id = self._get_country_id(items[ICity.countryCode])
         except Country.DoesNotExist:
             if self.noinsert:
@@ -396,6 +386,23 @@ It is possible to force the import of files which weren't downloaded using the
             )
         except Region.DoesNotExist:
             region_id = None
+
+        force_insert = False
+        force_update = False
+
+        try:
+            city = City.objects.get(geoname_id=items[ICity.geonameid])
+            force_update = True
+        except City.DoesNotExist:
+            try:
+                city = City.objects.get(name=items[ICity.name],
+                                        region_id=region_id)
+                force_update = True
+            except City.DoesNotExist:
+                if self.noinsert:
+                    return
+                city = City(geoname_id=items[ICity.geonameid])
+                force_insert = True
 
         save = False
         if city.country_id != country_id:


### PR DESCRIPTION
Geonames db contain duplictaes of cities
cities_light has unique key ('region', 'name')
In summary we have integrity errors on saving.

For checking, one of many, can find in cities1000.txt "Bykovo"
```
570298  Bykovo  Bykovo  Bykovo,Быково   55.63614        38.08027        P       PPL     RU              47                              10700           136     Europe/Moscow   2014-06-30
570300  Bykovo  Bykovo  Bykovo,Быково   55.62075        38.0797 P       PPL     RU              47                              1721            133     Europe/Moscow   2014-07-08
```

force_insert and force_update were taken out of TRY for static analisator.