### PR TITLE
Django3 broken: python_2_unicode_compatible

### DIFF
--- a/cities_light/abstract_models.py
+++ b/cities_light/abstract_models.py
@@ -5,7 +5,7 @@ import re
 import autoslug
 import pytz
 
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 
 from django.db import models
 from django.db.models import lookups


### PR DESCRIPTION
Django 3 has removed private Python 2 compatibility APIs
https://docs.djangoproject.com/en/3.0/releases/3.0/

please help install [pip install six](https://pypi.org/project/six/) instead of using from `django django.utils.encoding`
or tell me where is requirements.txt to let me update on it