### PR TITLE
Python 2 tidy ups and removed mock dependency

### DIFF
--- a/src/cities_light/abstract_models.py
+++ b/src/cities_light/abstract_models.py
@@ -55,7 +55,7 @@ class ToSearchIContainsLookup(lookups.IContains):
 
     def get_prep_lookup(self):
         """Return the value passed through to_search()."""
-        value = super(ToSearchIContainsLookup, self).get_prep_lookup()
+        value = super().get_prep_lookup()
         return to_search(value)
 
 

--- a/src/cities_light/admin.py
+++ b/src/cities_light/admin.py
@@ -97,7 +97,7 @@ class CityChangeList(ChangeList):
         if 'q' in list(request.GET.keys()):
             request.GET = copy(request.GET)
             request.GET['q'] = to_search(request.GET['q'])
-        return super(CityChangeList, self).get_queryset(request)
+        return super().get_queryset(request)
 
 
 class CityAdmin(admin.ModelAdmin):

--- a/src/cities_light/contrib/restframework3.py
+++ b/src/cities_light/contrib/restframework3.py
@@ -94,7 +94,7 @@ class CitiesLightListModelViewSet(viewsets.ReadOnlyModelViewSet):
         """
         Allows a GET param, 'q', to be used against name_ascii.
         """
-        queryset = super(CitiesLightListModelViewSet, self).get_queryset()
+        queryset = super().get_queryset()
 
         if self.request.GET.get('q', None):
             return queryset.filter(name_ascii__icontains=self.request.GET['q'])

--- a/src/cities_light/exceptions.py
+++ b/src/cities_light/exceptions.py
@@ -1,4 +1,3 @@
-
 class CitiesLightException(Exception):
     """ Base exception class for this app's exceptions. """
     pass
@@ -15,5 +14,4 @@ class InvalidItems(CitiesLightException):
 class SourceFileDoesNotExist(CitiesLightException):
     """ A source file could not be found. """
     def __init__(self, source):
-        super(SourceFileDoesNotExist, self).__init__(
-            '%s does not exist' % source)
+        super().__init__('%s does not exist' % source)

--- a/src/cities_light/management/commands/cities_light.py
+++ b/src/cities_light/management/commands/cities_light.py
@@ -65,7 +65,7 @@ It is possible to force the import of files which weren't downloaded using the
     logger = logging.getLogger('cities_light')
 
     def create_parser(self, *args, **kwargs):
-        parser = super(Command, self).create_parser(*args, **kwargs)
+        parser = super().create_parser(*args, **kwargs)
         parser.formatter_class = RawTextHelpFormatter
         return parser
 

--- a/src/cities_light/management/commands/cities_light_fixtures.py
+++ b/src/cities_light/management/commands/cities_light_fixtures.py
@@ -53,7 +53,7 @@ It is possible to force fixture download by using the --force-fetch option:
     CITY_FIXTURE = 'cities_light_city.json.bz2'
 
     def create_parser(self, *args, **kwargs):
-        parser = super(Command, self).create_parser(*args, **kwargs)
+        parser = super().create_parser(*args, **kwargs)
         parser.formatter_class = RawTextHelpFormatter
         return parser
 

--- a/src/cities_light/tests/base.py
+++ b/src/cities_light/tests/base.py
@@ -1,6 +1,6 @@
 """."""
 import os
-import mock
+from unittest import mock
 
 from django import test
 from django.core import management

--- a/src/cities_light/tests/test_downloader.py
+++ b/src/cities_light/tests/test_downloader.py
@@ -1,7 +1,7 @@
 """Downloader class tests."""
 import tempfile
 import time
-import mock
+from unittest import mock
 import logging
 
 from django import test

--- a/src/cities_light/tests/test_fixtures.py
+++ b/src/cities_light/tests/test_fixtures.py
@@ -1,7 +1,7 @@
 """Test for cities_light_fixtures management command."""
 import bz2
 import os
-import mock
+from unittest import mock
 
 from django import test
 from django.core.management import call_command

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,6 @@ deps =
     pytest
     pytest-django
     pytest-cov
-    mock
     coverage
     pylint
     pylint-django


### PR DESCRIPTION
Just a few small follow ups now that Python 3.6 is the lowest supported version.

I stopped short of changing `.format()` strings to `f-strings` as some folk have more mixed views on that. 