### PR TITLE
Default apps.py file to define the default primary key field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
-TBR
+2022-08-7
+    Default apps.py file to define the default primary key field
+
+2022-06-10
     Django 4.0 support
+
 
 2021-10-22 3.9.0
     Removed Tracis CI

--- a/src/cities_light/apps.py
+++ b/src/cities_light/apps.py
@@ -1,0 +1,4 @@
+from django.apps import AppConfig
+
+class CitiesLightConfig(AppConfig):
+    default_auto_field = 'django.db.models.AutoField'

--- a/src/cities_light/apps.py
+++ b/src/cities_light/apps.py
@@ -2,3 +2,4 @@ from django.apps import AppConfig
 
 class CitiesLightConfig(AppConfig):
     default_auto_field = 'django.db.models.AutoField'
+    name = 'cities_light'


### PR DESCRIPTION
default apps.py file to avoid the creation of the migration once the new project changes the **DEFAULT_AUTO_FIELD**