### PR TITLE
Use official dbdiff

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ deps =
     # sphinx
     Sphinx==4.2.0
     ; django-dbdiff
-    git+https://github.com/pfouque/django-dbdiff.git@fix312#egg=django-dbdiff
+    git+https://github.com/yourlabs/django-dbdiff.git@master#egg=django-dbdiff
 
 [test]
 deps =
@@ -43,7 +43,7 @@ deps =
     pylint-django
     djangorestframework
     ; django-dbdiff
-    git+https://github.com/pfouque/django-dbdiff.git@fix312#egg=django-dbdiff
+    git+https://github.com/yourlabs/django-dbdiff.git@master#egg=django-dbdiff
     django-ajax-selects==2.2.0
     django-autoslug==1.9.9
     graphene==3.3


### PR DESCRIPTION
After merge of https://github.com/yourlabs/django-dbdiff/pull/21 we can now get back to the official repository

NB: Keep using a git dependency since there is no new release