### PR TITLE
Alternate names as dict

### DIFF
--- a/src/cities_light/management/commands/cities_light.py
+++ b/src/cities_light/management/commands/cities_light.py
@@ -680,20 +680,16 @@ It is possible to force the import of files which weren't downloaded using the
                     continue
 
                 save = False
-                alternate_names = set()
+                alternate_names = dict()
                 for lang, names in geoname_data.items():
-                    if lang == 'post':
+                    if lang == "post":
                         # we might want to save the postal codes somewhere
                         # here's where it will all start ...
                         continue
 
-                    for name in names:
-                        if name == model.name:
-                            continue
-
-                        alternate_names.add(name)
-
-                alternate_names = ';'.join(sorted(alternate_names))
+                    # Append sorted values by length for each language
+                    alternate_names[lang] = sorted(names, key=len)
+                    
                 if model.alternate_names != alternate_names:
                     model.alternate_names = alternate_names
                     save = True

--- a/src/cities_light/management/commands/cities_light.py
+++ b/src/cities_light/management/commands/cities_light.py
@@ -682,7 +682,7 @@ It is possible to force the import of files which weren't downloaded using the
                 save = False
                 alternate_names = dict()
                 for lang, names in geoname_data.items():
-                    if lang == "post":
+                    if lang == 'post':
                         # we might want to save the postal codes somewhere
                         # here's where it will all start ...
                         continue

--- a/src/cities_light/receivers.py
+++ b/src/cities_light/receivers.py
@@ -38,19 +38,22 @@ def city_search_names(sender, instance, **kwargs):
 
     country_names = {instance.country.name, }
     if instance.country.alternate_names:
-        for n in instance.country.alternate_names.split(';'):
-            country_names.add(n)
+        country_alternate_names = eval(instance.country.alternate_names)
+        country_names = country_names.union(*country_alternate_names.values())
 
     city_names = {instance.name, }
     if instance.alternate_names:
-        for n in instance.alternate_names.split(';'):
-            city_names.add(n)
+        if isinstance(instance.alternate_names, str):
+            city_alternate_names = eval(instance.alternate_names)
+        else: 
+            city_alternate_names = instance.alternate_names
+        city_names = city_names.union(*city_alternate_names.values())
 
     if instance.region_id:
         region_names = {instance.region.name, }
         if instance.region.alternate_names:
-            for n in instance.region.alternate_names.split(';'):
-                region_names.add(n)
+            region_alternate_names = eval(instance.region.alternate_names)
+            region_names = region_names.union(*region_alternate_names.values())
     else:
         region_names = set()
 

--- a/src/cities_light/receivers.py
+++ b/src/cities_light/receivers.py
@@ -1,3 +1,6 @@
+import ast # solution 1
+# import json # solution 2
+
 from django.db.models import signals
 from .abstract_models import to_ascii, to_search
 from .settings import INCLUDE_CITY_TYPES, INCLUDE_COUNTRIES
@@ -38,22 +41,30 @@ def city_search_names(sender, instance, **kwargs):
 
     country_names = {instance.country.name, }
     if instance.country.alternate_names:
-        country_alternate_names = eval(instance.country.alternate_names)
+        # solution 1: literal_eval
+        country_alternate_names = ast.literal_eval(instance.country.alternate_names)
         country_names = country_names.union(*country_alternate_names.values())
+        # solution 2: json
 
     city_names = {instance.name, }
     if instance.alternate_names:
+        # for some reasons, city values come as both str and dict.
+        # solution 1: literal_eval
         if isinstance(instance.alternate_names, str):
-            city_alternate_names = eval(instance.alternate_names)
+            city_alternate_names = ast.literal_eval(instance.alternate_names)
         else: 
             city_alternate_names = instance.alternate_names
         city_names = city_names.union(*city_alternate_names.values())
+        # solution 2: json
 
     if instance.region_id:
         region_names = {instance.region.name, }
         if instance.region.alternate_names:
-            region_alternate_names = eval(instance.region.alternate_names)
+            # solution 1: literal_eval
+            region_alternate_names = ast.literal_eval(instance.region.alternate_names)
             region_names = region_names.union(*region_alternate_names.values())
+            # solution 2: json
+    
     else:
         region_names = set()
 


### PR DESCRIPTION
In this update, alternate names are now provided as a dictionary with language as a key and translations as value which is a sorted list based on string length. The code was tested and translations where loaded successfully. 

<img width="644" alt="django_cities_light_alternate_names" src="https://github.com/user-attachments/assets/7037be59-5462-43ec-9b57-5024aa4b05df" />
